### PR TITLE
Skip admin creation if user already exists

### DIFF
--- a/core/management/commands/setup.py
+++ b/core/management/commands/setup.py
@@ -27,25 +27,20 @@ logger = logging.getLogger(__name__)
 
 
 def create_service(name: str, exe: str | Path, args: str, log_file: Path):
-    """
-    This function creates a service using nssm.exe
-    name: The name of the service
-    exe: The executable to run
-    args: The arguments to pass to the executable
-    log_file: The log file to write to
-    """
-    # Migrate the database
+    ...
     logger.info("Migrating the database")
     subprocess.run(MIGRATE_COMMAND)
 
- # Make Superuser
-if TESTING:
-    from django.contrib.auth.models import User
-    try:
-        if not User.objects.filter(username='admin').exists():
-            User.objects.create_superuser('admin', 'admin@example.com', 'pass')
-    except Exception as e:
-        logger.exception(e)
+    # Make Superuser
+    if TESTING:
+        from django.contrib.auth.models import User
+        try:
+            if not User.objects.filter(username='admin').exists():
+                User.objects.create_superuser('admin', 'admin@example.com', 'pass')
+        except Exception as e:
+            logger.exception(e)
+
+
 
 
 

--- a/core/management/commands/setup.py
+++ b/core/management/commands/setup.py
@@ -38,13 +38,15 @@ def create_service(name: str, exe: str | Path, args: str, log_file: Path):
     logger.info("Migrating the database")
     subprocess.run(MIGRATE_COMMAND)
 
-    # Make Superuser
-    if TESTING:
-        from django.contrib.auth.models import User
-        try:
+ # Make Superuser
+if TESTING:
+    from django.contrib.auth.models import User
+    try:
+        if not User.objects.filter(username='admin').exists():
             User.objects.create_superuser('admin', 'admin@example.com', 'pass')
-        except Exception as e:
-            logger.exception(e)
+    except Exception as e:
+        logger.exception(e)
+
 
 
     if os.name == "nt":


### PR DESCRIPTION
This PR prevents a `UNIQUE constraint` error during setup by checking if the `admin` user already exists before attempting to create it. This ensures the script can be safely rerun without failing on duplicate user creation.
